### PR TITLE
use the Santa Cruz County assessors direct tax paid link

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -415,7 +415,8 @@
             countyStr = 'San Francisco';
             break;
           case 'SCZ':
-            taxUrl = 'http://ttc.co.santa-cruz.ca.us/Taxbills/';
+            const apnLookup = record.apn.replace(/-/g, '');
+            taxUrl = `https://sccounty01.co.santa-cruz.ca.us/ASR/ParcelList/linkHREF?txtAPN=${apnLookup}`;
             countyStr = 'Santa Cruz';
             disclaimer = `Parcel number ${record.apn}`;
             break;

--- a/app/index.html
+++ b/app/index.html
@@ -415,8 +415,7 @@
             countyStr = 'San Francisco';
             break;
           case 'SCZ':
-            const apnLookup = record.apn.replace(/-/g, '');
-            taxUrl = `https://sccounty01.co.santa-cruz.ca.us/ASR/ParcelList/linkHREF?txtAPN=${apnLookup}`;
+            taxUrl = `https://sccounty01.co.santa-cruz.ca.us/ASR/ParcelList/linkHREF?txtAPN=${record.apn.replace(/-/g, '')}`;
             countyStr = 'Santa Cruz';
             disclaimer = `Parcel number ${record.apn}`;
             break;


### PR DESCRIPTION
This allows the links to the tax data records on every Santa Cruz link to go straight to the tax page.