### PR TITLE
Updated Los Angeles to capture all tax payments

### DIFF
--- a/scrapers/los_angeles/parse.py
+++ b/scrapers/los_angeles/parse.py
@@ -8,7 +8,7 @@ import sys
 
 csv.field_size_limit(sys.maxsize)
 
-AMOUNT_REGEX = re.compile('installmentmoney fakeform\'>\$([,\.\d]+)</td>')
+AMOUNT_REGEX = re.compile('<td>Tax Amount</td>\s+<td class=\'installmentmoney fakeform\'>\$([,\.\d]+)</td>')
 
 def get_val(row, key):
     val = row[key].strip()
@@ -53,8 +53,8 @@ with open('/home/ian/Downloads/LA_County_Parcels.csv') as f_in, \
 
         amount = -1
         try:
-            amount_str = AMOUNT_REGEX.search(html).group(1).replace(',', '')
-            amount = float(amount_str)
+            amount_strs = AMOUNT_REGEX.findall(html)
+            amount = sum([float(s.replace(',', '')) for s in amount_strs])
         except:
             print('--> Could not parse float', amount_str)
             continue
@@ -75,6 +75,6 @@ with open('/home/ian/Downloads/LA_County_Parcels.csv') as f_in, \
             'apn': apn,
             'latitude': lat,
             'longitude': lng,
-            'tax': amount * 2,
+            'tax': amount,
             'county': 'LA',
         })


### PR DESCRIPTION
Previously, the parser took the first payment listed on the site and doubled it to get the property tax because most properties pay in two equal installments. However, some properties pay in more than two installments so it’s more accurate to add up all the taxes listed on the page. For example, see 5713-007-005.html which shows as 120k on the map but really pays 238k if you add up all the payments on the scraped html.